### PR TITLE
Add CLI agent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ cd backend
 pip install .
 ```
 
-**3. Run the Development Server:**
+**3. Run the CLI Agent:**
 
 ```bash
-make dev
+cd backend
+python -m agent.cli "<topic>"
 ```
-This starts the backend development server. Open your browser to `http://127.0.0.1:2024` to interact with the LangGraph UI.
+The CLI prints each step of the agent and writes the final JSON output to `result.json`.
 
 ## How the Backend Agent Works (High-Level)
 

--- a/backend/src/agent/cli.py
+++ b/backend/src/agent/cli.py
@@ -1,0 +1,37 @@
+import argparse
+import asyncio
+from pathlib import Path
+
+from langchain_core.messages import HumanMessage
+
+from agent.graph import graph
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the research agent from the CLI")
+    parser.add_argument("topic", nargs="?", help="Topic to research")
+    parser.add_argument("-o", "--output", default="result.json", help="File to store the final JSON")
+    return parser.parse_args()
+
+
+async def main() -> None:
+    args = parse_args()
+    topic = args.topic or input("Enter research topic: ").strip()
+
+    print(f"Starting research for: {topic}")
+    final_state = None
+    step = 1
+    async for event in graph.astream_events({"messages": [HumanMessage(content=topic)]}, version="v1"):
+        if event["event"] == "on_start":
+            print(f"Step {step}: {event['name']}")
+        if event["event"] == "on_end":
+            step += 1
+            final_state = event["data"]
+    if final_state and final_state.get("messages"):
+        output = final_state["messages"][-1].content
+        Path(args.output).write_text(output, encoding="utf-8")
+        print(f"Written result to {args.output}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `agent.cli` so the agent can run entirely from the command line
- update README with CLI instructions instead of UI-based dev server

## Testing
- `python -m py_compile backend/src/agent/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_684022c21a888324bc8944d0360ba3f1